### PR TITLE
Don't make assumptions about the baseURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   run: function(conf, app, url, callback) {
     var server;
     var agent = supertest.agent(url);
-    var baseURL = '/api/';
+    var baseURL = '/';
 
     if (typeof conf !== 'object') {
       return callback('Failed to load test configuration from file');


### PR DESCRIPTION
Let the user pass it as part of the `url` argument.
